### PR TITLE
Change `min(<array>, <valueExtractor>`) signature and returned value

### DIFF
--- a/src/functions/min/min.spec.ts
+++ b/src/functions/min/min.spec.ts
@@ -24,6 +24,13 @@ it('should return undefined when given null or undefined', () => {
   expect(result2).toEqual(expected2);
 });
 
+it('should return the minimum value of an array of numbers using a value extractor', () => {
+  const numbers = [2, 3, 4, 5];
+  const result = min(numbers, (n) => n * n);
+  const expected = 2;
+  expect(result).toEqual(expected);
+});
+
 it('should return the minimum value of an array of objects using a value extractor', () => {
   const people = [
     { name: 'Alice', age: 25 },
@@ -32,6 +39,6 @@ it('should return the minimum value of an array of objects using a value extract
   ];
 
   const result = min(people, (person) => person.age);
-  const expected = 20;
+  const expected = { name: 'Charlie', age: 20 };
   expect(result).toEqual(expected);
 });

--- a/src/functions/min/min.ts
+++ b/src/functions/min/min.ts
@@ -5,17 +5,17 @@ import type { Maybe } from '../../types';
  * @param array The array to iterate over.
  * @returns The maximum value in the array, or `undefined` if the array is empty or nil.
  */
-export function min<T>(array: Maybe<readonly T[]>): number;
+export function min(array: Maybe<readonly number[]>): number;
 /**
  * Computes the minimum value of array. If array is empty or nil, `undefined` is returned.
  * @param array The array to iterate over.
  * @param valueExtractor An optional function used to extract a numeric value from each element.
- * @returns The minimum value in the array, or `undefined` if the array is empty or nil.
+ * @returns The element with the minimum value in the array according to the `valueExtractor`, or `undefined` if the array is empty or nil.
  */
 export function min<T>(
   array: Maybe<readonly T[]>,
-  valueExtractor?: (value: T) => number
-): number;
+  valueExtractor: (value: T) => number
+): T | undefined;
 /**
  * Implementation for all overloads.
  * @param array The array to iterate over.
@@ -25,10 +25,12 @@ export function min<T>(
 export function min<T>(
   array: Maybe<readonly T[]>,
   valueExtractor: (value: T) => number = (value) => value as unknown as number
-): number | undefined {
+): T | number | undefined {
   if (array == null || array.length === 0) {
     return undefined;
   }
 
-  return Math.min(...array.map((element) => valueExtractor(element)));
+  return array.reduce((a, b) =>
+    valueExtractor(a) < valueExtractor(b) ? a : b
+  );
 }


### PR DESCRIPTION
the original implementation made using `min` with a value extractor less argonomic, since you had to

BREAKING CHANGE: the value returned by the `min` function, when passed a `valueExtractor` now
returns one of the items in the `array` as a result
